### PR TITLE
fix: add support for vite-ssg with `process.env.VITE_SSG`

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -27,7 +27,7 @@ export function ensureInstance() {
 export function getServerInstance() {
   const instance = getCurrentInstance()
 
-  if (instance?.proxy.$isServer)
+  if (process.env.VITE_SSG || instance?.proxy.$isServer)
     return instance.proxy as InstanceType<VueConstructor>
   return false
 }


### PR DESCRIPTION
Vite SSG does not set any `$isServer` variable to detect if it should server render, so this should do it fine!

https://github.com/antfu/vite-ssg/blob/0be88a5e14aeb9fe1c518642f5f72c99fc5bbfc7/src/node/build.ts#L77